### PR TITLE
Fix apparent typo in retain/reject table

### DIFF
--- a/bookdown/_book/hypothesistesting.html
+++ b/bookdown/_book/hypothesistesting.html
@@ -911,7 +911,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <tr class="header">
 <th></th>
 <th align="left">retain <span class="math inline">\(H_0\)</span></th>
-<th align="left">retain <span class="math inline">\(H_0\)</span></th>
+<th align="left">reject <span class="math inline">\(H_0\)</span></th>
 </tr>
 </thead>
 <tbody>


### PR DESCRIPTION
Hi, 
I was reading the bookdown version of this book and found what seems to be a pretty confusing typo. This table seems to be correct in the PDF version.